### PR TITLE
Honor normal variable SomeLib_INSTALL_CMAKEDIR

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,8 +1,10 @@
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-set(SomeLib_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/SomeLib"
-    CACHE STRING "Path to SomeLib CMake files")
+if (NOT DEFINED SomeLib_INSTALL_CMAKEDIR)
+   set(SomeLib_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/SomeLib"
+       CACHE STRING "Path to SomeLib CMake files")
+endif ()
 
 install(TARGETS SomeLib EXPORT SomeLib_Targets
         RUNTIME COMPONENT SomeLib_Runtime


### PR DESCRIPTION
While researching my "CMake without the agonizing pain" series, I discovered a bug that exhibits pathological behavior when `set(CACHE)` is used.